### PR TITLE
compatibility bugfix for python 3.10

### DIFF
--- a/multiphenics/fem/block_dirichlet_bc.py
+++ b/multiphenics/fem/block_dirichlet_bc.py
@@ -79,7 +79,7 @@ class BlockDirichletBC(BlockDirichletBC_Base):
         # https://stackoverflow.com/questions/2158395/flatten-an-irregular-list-of-lists
         def flatten(l):
             for el in l:
-                if isinstance(el, collections.Iterable):
+                if isinstance(el, collections.abc.Iterable):
                     for sub in flatten(el):
                         yield sub
                 else:


### PR DESCRIPTION
Hi Franchesco,

In python 3.10 collections.Iterable is deprecated, must change to collections.abc.Iterable. 
It alse works with older versions of python.